### PR TITLE
test: verify slugify keeps numbers and underscores

### DIFF
--- a/src/tests/slugify.test.ts
+++ b/src/tests/slugify.test.ts
@@ -20,6 +20,16 @@ describe("slugify function", () => {
     expect(slugify("Node.js & Express")).toBe("nodejs-express");
   });
 
+  it("should preserve numbers", () => {
+    expect(slugify("astro 101")).toBe("astro-101");
+    expect(slugify("version2")).toBe("version2");
+  });
+
+  it("should preserve underscores", () => {
+    expect(slugify("my_post_title")).toBe("my_post_title");
+    expect(slugify("post_2024")).toBe("post_2024");
+  });
+
   it("should trim spaces", () => {
     expect(slugify("  spaces  ")).toBe("spaces");
   });


### PR DESCRIPTION
## Summary
- add cases ensuring slugify preserves numeric characters
- add cases ensuring slugify preserves underscores

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68933853d358832a8ec0fc9bf18f861a