### PR TITLE
feat: redesign home page with JetBrains-inspired layout

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,40 +5,150 @@ const title = { page: "Jorman Espinoza" };
 ---
 
 <style>
-  .intro {
+  .ide {
     display: flex;
+    min-height: 60dvh;
+    background: #2b2b2b;
+    color: #a9b7c6;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+    font-family: var(--code-font);
+  }
+
+  .sidebar {
+    background: #3c3f41;
+    width: 50px;
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: var(--gap);
+    padding: 0.5rem 0;
+    gap: 0.5rem;
+    user-select: none;
   }
 
-  h2 {
-    font-style: italic;
+  .sidebar span {
+    font-size: 1.2rem;
   }
 
-  img {
-    width: 225px;
-    height: 225px;
-    margin-bottom: 1em;
-    border: 3px solid var(--border-color);
-    border-inline-start: 3px solid var(--accent-color);
-    border-radius: 50%;
+  .editor {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
   }
 
-  p {
-    text-wrap: pretty;
-    max-width: 50dvw;
+  .tabs {
+    display: flex;
+    background: #313335;
+    font-family: var(--main-font);
+  }
+
+  .tab {
+    padding: 0.4rem 1rem;
+    background: #3c3f41;
+    color: #a9b7c6;
+    border-right: 1px solid #2b2b2b;
+  }
+
+  .tab.active {
+    background: #2b2b2b;
+  }
+
+  .code {
+    flex: 1;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .line {
+    display: flex;
+  }
+
+  .line-number {
+    width: 2rem;
+    text-align: right;
+    padding-right: 1rem;
+    color: #606366;
+    user-select: none;
+  }
+
+  .line-code {
+    flex: 1;
+  }
+
+  .keyword {
+    color: #cc7832;
+  }
+
+  .string {
+    color: #6a8759;
+  }
+
+  .func {
+    color: #ffc66d;
+  }
+
+  .comment {
+    color: #808080;
   }
 </style>
 
 <Layout title={title}>
-  <div class="intro">
-    <div>
-      <p>
-        Me he desempeñado en distintos equipos tanto como Backend como Frontend,
-        soy un apasionado del código limpio, siempre buscando generar soluciones
-        que cumplan y superen las expectativas de clientes.
-      </p>
-      <Socials template="icons" />
+  <div class="ide">
+    <div class="sidebar">
+      <span>📁</span>
+      <span>🔍</span>
+      <span>⚙️</span>
+    </div>
+    <div class="editor">
+      <div class="tabs">
+        <div class="tab active">home.ts</div>
+      </div>
+      <div class="code">
+        <div class="line">
+          <span class="line-number">1</span>
+          <span class="line-code"
+            ><span class="keyword">const</span> name = <span class="string"
+              >"Jorman Espinoza"</span
+            ></span
+          >
+        </div>
+        <div class="line">
+          <span class="line-number">2</span>
+          <span class="line-code"
+            ><span class="keyword">const</span> role = <span class="string"
+              >"Desarrollador de Software"</span
+            ></span
+          >
+        </div>
+        <div class="line">
+          <span class="line-number">3</span>
+          <span class="line-code"
+            ><span class="keyword">function</span>
+            <span class="func">greet</span>() {"{"}
+          </span>
+        </div>
+        <div class="line">
+          <span class="line-number">4</span>
+          <span class="line-code"
+            >&nbsp;&nbsp;<span class="keyword">return</span>
+            <span class="string">`Bienvenido a mi portafolio`</span>;</span
+          >
+        </div>
+        <div class="line">
+          <span class="line-number">5</span>
+          <span class="line-code">{"}"}</span>
+        </div>
+        <div class="line">
+          <span class="line-number">6</span>
+          <span class="line-code"
+            ><span class="comment">// {Astro.site?.href || ""}</span></span
+          >
+        </div>
+      </div>
     </div>
   </div>
+  <Socials template="icons" />
 </Layout>


### PR DESCRIPTION
## Summary
- restyle home page with JetBrains-like IDE layout
- showcase developer info in code editor snippet

## Testing
- `pnpm test`
- `GOOGLE_MAPS_API_KEY=dummy pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a25edc21f0832a96545c1f75a76bd4